### PR TITLE
prevent one decimal place

### DIFF
--- a/src/helper/validateAmount.ts
+++ b/src/helper/validateAmount.ts
@@ -7,6 +7,6 @@ export default function validateAmount(amount: number | string): string {
   if (!amount) throw new Error("Amount is required");
   if (typeof amount === "string") amount = Number(amount);
   if (isNaN(amount)) throw new Error("Amount must be a number");
-  if (Number(amount) === amount && amount % 1 === 0) amount = amount.toFixed(2);
+  amount = amount.toFixed(2);
   return String(amount);
 }


### PR DESCRIPTION
## Problem:
current validation is missing "preventing one decimal place values)
example.
```validateAmount(2.1) // "2.1" 👎```

## This PR solves by converting to 2 decimal places anyways:
 ```validateAmount(2.1) // "2.10" 👍```
  ```validateAmount(3.31) // "3.31" 👍```
  ``validateAmount("44") // "44.00" 👍```